### PR TITLE
update action to use node:16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,5 +2,5 @@ name: Setup Jsonnet
 description: Setup jsonnet and jsonnet-bundler
 author: Hiroaki Kobayashi
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Currently the action gives a warning: 
```Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: kobtea/setup-jsonnet-action@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.```